### PR TITLE
Updated workers to have up-to-date crawler classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7137,9 +7137,9 @@
             "dev": true
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
             "funding": [
                 {
                     "type": "individual",
@@ -12556,9 +12556,9 @@
             "dev": true
         },
         "node_modules/undici": {
-            "version": "5.26.3",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.3.tgz",
-            "integrity": "sha512-H7n2zmKEWgOllKkIUkLvFmsJQj062lSm3uA4EYApG8gLuiOM0/go9bIoC3HVaSnfg4xunowDE2i9p8drkXuvDw==",
+            "version": "5.28.3",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+            "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
             "dependencies": {
                 "@fastify/busboy": "^2.0.0"
             },
@@ -18254,9 +18254,9 @@
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.15.1",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
-            "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+            "version": "1.15.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+            "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw=="
         },
         "form-data": {
             "version": "4.0.0",
@@ -22223,9 +22223,9 @@
             "dev": true
         },
         "undici": {
-            "version": "5.26.3",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.3.tgz",
-            "integrity": "sha512-H7n2zmKEWgOllKkIUkLvFmsJQj062lSm3uA4EYApG8gLuiOM0/go9bIoC3HVaSnfg4xunowDE2i9p8drkXuvDw==",
+            "version": "5.28.3",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+            "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
             "requires": {
                 "@fastify/busboy": "^2.0.0"
             }

--- a/src/common/utils/common-utils.ts
+++ b/src/common/utils/common-utils.ts
@@ -3,6 +3,13 @@ import axios from 'axios';
 import { JSDOM } from 'jsdom';
 
 /**
+ * 
+ * @param {number} ms - Number of milliseconds to wait for.
+ * @returns {Promise<void>} - A resolution when timer has waited for the allotted time.
+ */
+export const sleep = async(ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
  * This function is wrapped in a setImmediate to schedule execution
  * This will trigger at the end of the current event loop to ensure other processing is complete.
  * See: https://nodejs.org/en/docs/guides/timers-in-node/
@@ -39,12 +46,13 @@ export const retryHandler = (
     tries: number,
     counter?: number
 ): void => {
-    fn().catch(() => {
+    fn().catch((e) => {
         if (tries === 1) {
             return console.error(
                 `Function: ${fn.name} failed... (Tried ${counter} times).`
             );
         }
+        console.debug(e);
         console.error(`Function: ${fn.name} failed... Retrying.`);
         return retryHandler(fn, tries - 1, counter ?? tries);
     });

--- a/src/workers/news-worker.ts
+++ b/src/workers/news-worker.ts
@@ -4,6 +4,7 @@ import {
     dateGenerator,
     fetchArticles,
     retryHandler,
+    sleep,
     staticRefresher,
 } from '@common/utils/common-utils';
 import { IO } from '@server';
@@ -105,7 +106,7 @@ export const getRPSNews = (): Promise<void> =>
 export const getPCGamerNews = (): Promise<void> =>
     fetchArticles(
         'https://www.pcgamer.com/uk/news/',
-        "[data-list='news/news/latest']",
+        "[data-list='home/latest']",
         '.listingResult'
     ).then((HTMLArticles: Element[]) => {
         const site: string = 'PCGamer';
@@ -116,6 +117,7 @@ export const getPCGamerNews = (): Promise<void> =>
                 HTMLDivElement.querySelector(
                     '.article-name'
                 )?.textContent?.trim();
+
             if (title) {
                 const url: string =
                     HTMLDivElement.querySelector('a')?.href ?? 'Not Found';
@@ -146,36 +148,31 @@ export const getPCGamerNews = (): Promise<void> =>
 /**
  * This function gets news for the given outlet
  * @returns {void} - Writes data to storage object
+ * 
+ * Note: This function is a tad messy due to BBC deciding to restructure their classes
+ *       They no longer provide timestamps for articles and have multiple titles (one being hidden?) in some cases
+ * 
+ * TODO: Adjust this function to be cleaner, it's currently a simple solution
  */
 export const getUKNews = (): Promise<void> =>
     fetchArticles(
         'https://www.bbc.co.uk/news/england',
-        '#topos-component',
-        '.gs-t-News'
+        '[role="list"]',
+        '[type="article"]'
     ).then((HTMLArticles: Element[]) => {
         const site: string = 'BBC';
         const articles: NewsArticle[] = [];
         const articleTitles: string[] = [];
 
         HTMLArticles.forEach((HTMLDivElement) => {
-            const title: UndefinedNews = HTMLDivElement.querySelector(
-                '.gs-c-promo-heading__title'
-            )?.textContent?.trim();
+            const titles = HTMLDivElement.querySelector(
+                '[role="text"]'
+            )?.childNodes;
+            
+            const title = titles ? (titles[1] ? titles[1].textContent : titles[0].textContent) : undefined;
 
             if (title) {
-                let imgUrl: UndefinedNews =
-                    HTMLDivElement.querySelector('img')?.getAttribute(
-                        'data-src'
-                    );
-
-                if (imgUrl) {
-                    imgUrl = imgUrl.replace(/\{width}/g, '720');
-                } else {
-                    imgUrl =
-                        HTMLDivElement.querySelector('img')?.src ?? 'Not Found';
-                }
-
-                const img = imgUrl;
+                let img: UndefinedNews = HTMLDivElement.querySelector('img')?.src ?? 'Not Found'
 
                 let url: string =
                     HTMLDivElement.querySelector('a')?.href ?? 'Not Found';
@@ -184,11 +181,10 @@ export const getUKNews = (): Promise<void> =>
                     url = `https://www.bbc.co.uk${url}`;
                 }
 
-                const date: string = dateGenerator(
-                    HTMLDivElement.querySelector('time')?.getAttribute(
-                        'datetime'
-                    )
-                );
+                // This has to be included as the BBC no longer provides timestamps in their articles
+                // So we have to index by order of collection, rather than date of post
+                sleep(1);
+                const date = new Date().toString();
 
                 const live =
                     HTMLDivElement.querySelector('a')?.href.split('/')[2] ??

--- a/src/workers/news-worker.ts
+++ b/src/workers/news-worker.ts
@@ -168,8 +168,8 @@ export const getUKNews = (): Promise<void> =>
             const titles = HTMLDivElement.querySelector(
                 '[role="text"]'
             )?.childNodes;
-            
-            const title = titles ? (titles[1] ? titles[1].textContent : titles[0].textContent) : undefined;
+
+            const title = titles ? (titles[1] ? titles[1].textContent?.trim() : titles[0].textContent?.trim()) : undefined;
 
             if (title) {
                 let img: UndefinedNews = HTMLDivElement.querySelector('img')?.src ?? 'Not Found'
@@ -184,7 +184,7 @@ export const getUKNews = (): Promise<void> =>
                 // This has to be included as the BBC no longer provides timestamps in their articles
                 // So we have to index by order of collection, rather than date of post
                 sleep(1);
-                const date = new Date().toString();
+                const date = new Date().toISOString();
 
                 const live =
                     HTMLDivElement.querySelector('a')?.href.split('/')[2] ??

--- a/tests/data/default.html
+++ b/tests/data/default.html
@@ -1,37 +1,29 @@
 <!DOCTYPE html>
 <html lang="html">
-    <head>
-        <title>Test Page</title>
-    </head>
-    <body>
-        <div
-            data-list="to-replace-article-container"
-            id="to-replace-article-container"
-            class="to-replace-article-container"
-        >
-            <ul>
-                <li>
-                    <article class="to-replace-article-divider">
-                        <img
-                            data-original="test-img.png"
-                            class="to-replace-image-class"
-                            src="test-img.png"
-                            data-src="test-img.png"
-                            alt="testing"
-                        />
-                        <h4 class="to-replace-title-class">
-                            Test Title to-replace-inner-title-div
-                        </h4>
-                        <time
-                            class="relative-date"
-                            datetime="2023-02-01T15:46:04.563Z"
-                        >
-                            Just Now
-                        </time>
-                        <a href="/test">Test Link</a>
-                    </article>
-                </li>
-            </ul>
-        </div>
-    </body>
+
+<head>
+    <title>Test Page</title>
+</head>
+
+<body>
+    <div role="to-replace-article-container" data-list="to-replace-article-container" id="to-replace-article-container"
+        class="to-replace-article-container">
+        <ul>
+            <li>
+                <article type="to-replace-article-divider" class="to-replace-article-divider">
+                    <img data-original="test-img.png" class="to-replace-image-class" src="test-img.png"
+                        data-src="test-img.png" alt="testing" />
+                    <h4 role="to-replace-title-class" class="to-replace-title-class">
+                        Test Title to-replace-inner-title-div
+                    </h4>
+                    <time class="relative-date" datetime="2023-02-01T15:46:04.563Z">
+                        Just Now
+                    </time>
+                    <a href="/test">Test Link</a>
+                </article>
+            </li>
+        </ul>
+    </div>
+</body>
+
 </html>

--- a/tests/data/test-data.ts
+++ b/tests/data/test-data.ts
@@ -38,7 +38,7 @@ export const rpsContent = () => {
 export const pcgContent = () => {
     return replacer(
         template,
-        'news/news/latest',
+        'home/latest',
         'listingResult',
         'article-name',
         'article-lead-image-wrap'
@@ -48,9 +48,9 @@ export const pcgContent = () => {
 export const bbcContent = () => {
     return replacer(
         template,
-        'topos-component',
-        'gs-t-News',
-        'gs-c-promo-heading__title',
+        'list',
+        'article',
+        'text',
         ''
     );
 };

--- a/tests/unit/news-worker.test.ts
+++ b/tests/unit/news-worker.test.ts
@@ -201,7 +201,7 @@ describe('News-Worker should collect news as expected', () => {
             "BBC's Latest News.",
             [
                 {
-                    date: '2023-02-01T15:46:04.563Z',
+                    date: (storageSpy.mock.calls[0][3] as any)[0].date,
                     img: 'test-img.png',
                     title: 'Test Title',
                     url: 'https://www.bbc.co.uk/test',
@@ -218,9 +218,9 @@ describe('News-Worker should collect news as expected', () => {
         const commonUtils = require('../../src/common/utils/common-utils');
         const document = new JSDOM(`
             <li>
-                <div class="li">
-                    <div class="gs-c-promo-heading__title">
-                        Test Title
+                <div type="article">
+                    <div role="text">
+                        <span>Test Title</span>
                     </div>
                 </div>
             </li>
@@ -236,7 +236,7 @@ describe('News-Worker should collect news as expected', () => {
         expect(storageSpy.mock.calls[0][3]).toEqual([
             {
                 title: 'Test Title',
-                date: new Date().toISOString(),
+                date: (storageSpy.mock.calls[0][3] as any)[0].date,
                 img: 'Not Found',
                 url: 'Not Found',
             },


### PR DESCRIPTION
Overview:
BBC and PCGamer have simultaneously decided to change their classes/attributes on their HTML. 
The crawlers do not understand this change and have broken both the feeds, I've updated the element queries to reflect changes.

Issues:
- BBC no longer indexes by date correctly as their webpage doesn't have timestamps anymore (WHY???)

Changes:
- Updated PCGamer to use a new attribute for searching
- Updated BBC to use new attributes for searching, indexing now done by collection order rather than date.
